### PR TITLE
When rsyncing to the build folder delete files that don't exist in the source

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -101,7 +101,7 @@ if ! command -v 'rsync'; then
 fi
 
 echo "Syncing files... quietly"
-rsync -a "${SRC_DIR}/" "${BUILD_DIR}" --exclude='.git/'
+rsync --delete -a "${SRC_DIR}/" "${BUILD_DIR}" --exclude='.git/'
 
 # Make up the commit, commit, and push
 # ------------------------------------


### PR DESCRIPTION
Fixes #12 
Built branches should only every contain the source directory plus any files generated by the build process. If files in a new commit result in less/removed files in the built version, those files should be removed from the deploy.