### PR TITLE
Add support for .deployignore file

### DIFF
--- a/.circleci/config-sample.yml
+++ b/.circleci/config-sample.yml
@@ -72,7 +72,3 @@ jobs:
           name: Deploy -built branch to github
           command: bash <(curl -s "https://raw.githubusercontent.com/Automattic/vip-go-build/master/deploy.sh")
 
-      - run:
-          name: Verify that -built branch was deployed correctly
-          command: ./tests/verify-circle.sh
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       # This will push the result to the {currentbranch}-built branch
       - deploy:
           name: Deploy -built branch to github
-          command: bash <(curl -s "https://raw.githubusercontent.com/Automattic/vip-go-build/master/deploy.sh")
+          command: ./deploy.sh
 
       - run:
           name: Verify that -built branch was deployed correctly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,24 +12,12 @@ jobs:
     branches:
       # Don't build from a branch with the `-built` suffix, to
       # prevent endless loops of deploy scripts.
-      # REQUIRED: If you're amended an existing config, the below are two
-      # of the required lines you must add
       ignore:
         - /^.*-built$/
 
     steps:
       - checkout
 
-      # @TODO: Configure build steps
-      # - run: npm install
-      # - run: npm run build
-      #
-      # These can also be specified with a name:
-      # - run:
-      #   name: Build the thing
-      #   command: npm run build-thing
-
-      # @TODO: modify or remove this example
       - run: echo "Building..."
       - run:
           name: Create build directory
@@ -59,15 +47,9 @@ jobs:
               echo "Build failed, file missing"; exit 1
             fi
 
-      # Uncomment this and supply your ssh fingerprint to enable CircleCI to push the built branch to GitHub
-      #- add_ssh_keys:
-      #    fingerprints:
-      #      - "ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff:ff"
-
       # Run the deploy:
-      # REQUIRED: If you're amended an existing config, the below are two
-      # of the required lines you must add
       # This will push the result to the {currentbranch}-built branch
+      # Note: if running multiple times, you may need to `git push --delete origin {currentbranch}` between runs to clear out the branch.
       - deploy:
           name: Deploy -built branch to github
           command: ./deploy.sh

--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,1 @@
+fixtures/skip-this-file.txt

--- a/deploy.sh
+++ b/deploy.sh
@@ -112,8 +112,13 @@ BUILD_DEPLOYIGNORE_PATH="${BUILD_DIR}/.deployignore"
 if [ -f $BUILD_DEPLOYIGNORE_PATH ]; then
 	BUILD_GITIGNORE_PATH="${BUILD_DIR}/.gitignore"
 
-	echo "-- found .deployignore; removing all gitignore files"
-	find $BUILD_DIR -type f -name '.gitignore' -exec rm {} \;
+	rm $BUILD_GITIGNORE_PATH
+
+	echo "-- found .deployignore; emptying all gitignore files"
+	find $BUILD_DIR -type f -name '.gitignore' | while read GITIGNORE_FILE; do
+		echo "# Emptied by vip-go-build; '.deployignore' exists and used as global .gitignore. See https://wp.me/p9nvA-89A" > $GITIGNORE_FILE
+		echo "${GITIGNORE_FILE}"
+	done
 
        	echo "-- using .deployignore as global .gitignore"
 	mv $BUILD_DEPLOYIGNORE_PATH $BUILD_GITIGNORE_PATH 

--- a/deploy.sh
+++ b/deploy.sh
@@ -101,7 +101,23 @@ if ! command -v 'rsync'; then
 fi
 
 echo "Syncing files... quietly"
+
 rsync --delete -a "${SRC_DIR}/" "${BUILD_DIR}" --exclude='.git/'
+
+# gitignore override
+# To allow commiting built files in the build branch (which are typically ignored)
+# -------------------
+
+BUILD_DEPLOYIGNORE_PATH="${BUILD_DIR}/.deployignore"
+if [ -f $BUILD_DEPLOYIGNORE_PATH ]; then
+	BUILD_GITIGNORE_PATH="${BUILD_DIR}/.gitignore"
+
+	echo "-- found .deployignore; removing all gitignore files"
+	find $BUILD_DIR -type f -name '.gitignore' -exec rm {} \;
+
+       	echo "-- using .deployignore as global .gitignore"
+	mv $BUILD_DEPLOYIGNORE_PATH $BUILD_GITIGNORE_PATH 
+fi
 
 # Make up the commit, commit, and push
 # ------------------------------------

--- a/deploy.sh
+++ b/deploy.sh
@@ -112,7 +112,9 @@ BUILD_DEPLOYIGNORE_PATH="${BUILD_DIR}/.deployignore"
 if [ -f $BUILD_DEPLOYIGNORE_PATH ]; then
 	BUILD_GITIGNORE_PATH="${BUILD_DIR}/.gitignore"
 
-	rm $BUILD_GITIGNORE_PATH
+	if [ -f $BUILD_GITIGNORE_PATH ]; then
+		rm $BUILD_GITIGNORE_PATH
+	fi
 
 	echo "-- found .deployignore; emptying all gitignore files"
 	find $BUILD_DIR -type f -name '.gitignore' | while read GITIGNORE_FILE; do

--- a/fixtures/skip-this-file.txt
+++ b/fixtures/skip-this-file.txt
@@ -1,0 +1,1 @@
+This file should not be pushed to the built branch!

--- a/tests/verify-circle.sh
+++ b/tests/verify-circle.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+DEPLOY_SUFFIX="${VIP_DEPLOY_SUFFIX:--built}"
+DEPLOY_BRANCH="${CIRCLE_BRANCH}${DEPLOY_SUFFIX}"
+REPO_SLUG="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+REPO_SSH_URL="git@github.com:${REPO_SLUG}"
+VERIFY_DIR="/tmp/vip-go-build-verify-$(date +%s)"
+
+if [[ -d "$VERIFY_DIR" ]]; then
+	echo "ERROR: ${VERIFY_DIR} already exists."
+	echo "This should not happen, and something is probably broken!"
+	exit 1
+fi
+
+echo "Verifying built branch: ${DEPLOY_BRANCH} for ${REPO_SSH_URL} in ${VERIFY_DIR}"
+
+git clone --depth 1 --single-branch --branch "${DEPLOY_BRANCH}" "${REPO_SSH_URL}" "${VERIFY_DIR}"
+
+cd "${VERIFY_DIR}"
+
+echo ""
+echo "## Running some tests"
+echo ""
+
+README_FILE="build/README.md"
+if [ ! -f "${README_FILE}" ]; then
+	echo "- Generated file (${README_FILE}) was not found; something is broken!": exit 1
+else
+	echo "- ${README_FILE} looks good!"
+fi
+
+echo ""
+
+SKIPPED_FILE="fixtures/skip-this-file.txt"
+if [ -f "${SKIPPED_FILE}" ]; then
+	echo "- Found file (${SKIPPED_FILE}) that should have been ignored; something is broken!"; exit 1
+else
+	echo "- ${SKIPPED_FILE} looks good!"
+fi


### PR DESCRIPTION
Typically built files are gitignore-d which means that to push them to our built branch, we often need annoying workarounds.

This allows the ability to provide a global deployignore file instead which substitutes the standard gitignore file.

One caveat here is that all `.gitignore` files are removed for this to work, and we need to make that very clear in setup docs (to avoid unexpected files being committed to a built branch).

Fixes #11 

### TODO

- [x] Look into adding tests for Cirlce CI to make sure this is working as expected
- [ ] Docs

### To Test

1. Check out this PR
1. Check out another working GitHub repo with a `master` branch.
1. Make a change to a file.
1. Run the following (with the `[]` values updated; `[repo]` should be something like `org/repo`; `[sha]` should the latest commit sha; `[path/to/deploy.sh]` should the path to deploy file in the checkout in step 1:

```
CIRCLE_REPO_SLUG=[repo] CIRCLE_SHA1=[sha] CIRCLE_BRANCH=master [path/to/deploy.sh]
```

Verify that the script worked all the way through without issue and the change was committed and pushed.

Next:

1. Add a `.deployignore` file to the working repo.
1. Add a file called `skip.txt` to the folder
1. Add `skip.txt` to `deployignore`.
1. Add another file called `copy.txt`.
1. In a subfolder, add a `.gitignore` file with an entry in that file. Also create that file that is being ignored.
1. Run the script similar to above.

Verify that `skip.txt` is not in the target repo.
Verify that `copy.txt` is in the target repo.
Verify that the gitignore-d file is in the target repo.