### PR TITLE
don't update submodules when cloning them

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -88,7 +88,7 @@ else
 fi
 
 # Expand all submodules
-git submodule update --init --recursive;
+git submodule init
 
 # Copy the files over
 # -------------------


### PR DESCRIPTION
If I need commit X from May, but a new commit Y is made from July, VIPs deploy script always updates to the newer undesired commit because it updates all submodules references when it initialises them.

![](https://media.giphy.com/media/7BK6kMXAO7R8k/source.gif)

There's a better way! Just use `git submodule init` instead. Clients can update their submodules themselves, and you have a bot that can do these things too!  Don't break their stuff :(