### PR TITLE
Ignore rsync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#322D24",
+    "titleBar.activeBackground": "#473F32",
+    "titleBar.activeForeground": "#FBFAF9"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#322D24",
-    "titleBar.activeBackground": "#473F32",
-    "titleBar.activeForeground": "#FBFAF9"
-  }
-}

--- a/deploy.sh
+++ b/deploy.sh
@@ -109,7 +109,7 @@ rsync \
 	--exclude ".revision" \
 	--exclude ".deployment-state" \
 	--exclude node_modules/ \
-	--exclude no-vip/
+	--exclude no-vip /
 	--delete
 
 # gitignore override

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,7 +28,7 @@ fi
 REPO_SLUG=${CIRCLE_REPO_SLUG:-$TRAVIS_REPO_SLUG}
 REPO_SSH_URL="git@github.com:${REPO_SLUG}"
 COMMIT_SHA=${CIRCLE_SHA1:-$TRAVIS_COMMIT}
-COMMIT_MESSAGE=${TRAVIS_COMMIT_MESSAGE:"fallback"}
+COMMIT_MESSAGE=${TRAVIS_COMMIT_MESSAGE}
 DEPLOY_BRANCH="${BRANCH}${DEPLOY_SUFFIX}"
 cd $SRC_DIR
 COMMIT_AUTHOR_NAME="$( git log --format=%an -n 1 ${COMMIT_SHA} )"
@@ -150,10 +150,10 @@ if [ -z "$(git status --porcelain)" ]; then
 fi
 
 # Commit it.
-MESSAGE=$( printf 'Build changes from %s\n\n%s' "${COMMIT_SHA}" "${CIRCLE_BUILD_URL}" )
+MESSAGE=$( printf 'Build changes from %s\n\n%s\n\\n%s' "${COMMIT_SHA}" "${CIRCLE_BUILD_URL}" "${COMMIT_MESSAGE}" )
 # Set the Author to the commit (expected to be a client dev) and the committer
 # will be set to the default Git user for this CI system
-git commit --author="${COMMIT_AUTHOR_NAME} <${COMMIT_AUTHOR_EMAIL}>" -m "${MESSAGE}" -m "${COMMIT_MESSAGE}"
+git commit --author="${COMMIT_AUTHOR_NAME} <${COMMIT_AUTHOR_EMAIL}>" -m "${MESSAGE}"
 
 # Push it (push it real good).
 git push origin "${DEPLOY_BRANCH}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -150,7 +150,7 @@ if [ -z "$(git status --porcelain)" ]; then
 fi
 
 # Commit it.
-MESSAGE=$( printf 'Build changes from %s\n\n%s\n\\n%s' "${COMMIT_SHA}" "${CIRCLE_BUILD_URL}" "${COMMIT_MESSAGE}" )
+MESSAGE=$( printf 'Build changes from %s\n\n%s\n\n%s' "${COMMIT_SHA}" "${CIRCLE_BUILD_URL}" "${COMMIT_MESSAGE}" )
 # Set the Author to the commit (expected to be a client dev) and the committer
 # will be set to the default Git user for this CI system
 git commit --author="${COMMIT_AUTHOR_NAME} <${COMMIT_AUTHOR_EMAIL}>" -m "${MESSAGE}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -109,7 +109,7 @@ rsync \
 	--exclude ".revision" \
 	--exclude ".deployment-state" \
 	--exclude node_modules/ \
-	--exclude no-vip /
+	--exclude no-vip \
 	--delete
 
 # gitignore override


### PR DESCRIPTION
Code Reviewing and then preparing to PR against automattic's repository:

# Description
* Ignores some heavy folders when `rsync`-ing
* Passing the commit message along with the built commit (allows for the original commit to be used and reference any ticket therein)