### PR TITLE
Update to use cimg for image

### DIFF
--- a/.circleci/config-sample.yml
+++ b/.circleci/config-sample.yml
@@ -6,8 +6,8 @@ jobs:
       # building from https://hub.docker.com/r/cimg/node/tags
       #
       # Note: If using a different container, make sure it contains at least
-      # git 2.6.0. (Use -stretch for circleci/node containers.)
-      - image: cimg/node:12.16-stretch
+      # git 2.6.0.
+      - image: cimg/node:12.16
 
     branches:
       # Don't build from a branch with the `-built` suffix, to

--- a/.circleci/config-sample.yml
+++ b/.circleci/config-sample.yml
@@ -3,11 +3,11 @@ jobs:
   build:
     docker:
       # Pick a base image which matches the version of Node you need for
-      # building from https://hub.docker.com/r/circleci/node/tags/
+      # building from https://hub.docker.com/r/cimg/node/tags
       #
       # Note: If using a different container, make sure it contains at least
       # git 2.6.0. (Use -stretch for circleci/node containers.)
-      - image: circleci/node:6.11-stretch
+      - image: cimg/node:12.16-stretch
 
     branches:
       # Don't build from a branch with the `-built` suffix, to

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ jobs:
   build:
     docker:
       # Pick a base image which matches the version of Node you need for
-      # building from https://hub.docker.com/r/circleci/node/tags/
+      # building from https://hub.docker.com/r/cimg/node/tags
       #
       # Note: If using a different container, make sure it contains at least
       # git 2.6.0. (Use -stretch for circleci/node containers.)
-      - image: circleci/node:6.11-stretch
+      - image: cimg/node:12.6-stretch
 
     branches:
       # Don't build from a branch with the `-built` suffix, to

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ jobs:
         - /^.*-built$/
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "50:96:13:4c:e9:68:ee:7e:02:3a:b1:bd:dc:81:7d:d1"
+
       - checkout
 
       - run: echo "Building..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ jobs:
       # building from https://hub.docker.com/r/cimg/node/tags
       #
       # Note: If using a different container, make sure it contains at least
-      # git 2.6.0. (Use -stretch for circleci/node containers.)
-      - image: cimg/node:12.6-stretch
+      # git 2.6.0.
+      - image: cimg/node:12.6
 
     branches:
       # Don't build from a branch with the `-built` suffix, to

--- a/deploy.sh
+++ b/deploy.sh
@@ -96,8 +96,8 @@ git submodule update --init --recursive;
 if ! command -v 'rsync'; then
 	# @FIXME Probably there's a way we could check if APT is up to date or not
 	# so we don't have to run update every time
-	sudo apt-get update
-	sudo apt-get install -q -y rsync
+	apt-get update
+	apt-get install -q -y rsync
 fi
 
 echo "Syncing files... quietly"


### PR DESCRIPTION
## Description

Update the sample image reference `circleci` to use the next-generation `cimg` instead. [According to docs:](https://circleci.com/docs/2.0/circleci-images/)

> The legacy CircleCI convenience images are Debian Jessie- or Stretch-based images, however the next-gen images, cimg, extend the official Ubuntu image. 